### PR TITLE
Set search result to modified date descending

### DIFF
--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.Everything/SearchHelper/EverythingApi.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.Everything/SearchHelper/EverythingApi.cs
@@ -137,6 +137,8 @@ namespace Community.PowerToys.Run.Plugin.Everything.SearchHelper
             if (token.IsCancellationRequested) { return results; }
             EverythingApiDllImport.Everything_SetOffset(0);
             if (token.IsCancellationRequested) { return results; }
+            EverythingApiDllImport.Everything_SetSort(14);
+            if (token.IsCancellationRequested) { return results; }
             EverythingApiDllImport.Everything_SetMax(maxCount);
             if (token.IsCancellationRequested) { return results; }
             EverythingApiDllImport.Everything_SetSearchW(keyWord);

--- a/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.Everything/SearchHelper/EverythingApiDllImport.cs
+++ b/src/modules/launcher/Plugins/Community.PowerToys.Run.Plugin.Everything/SearchHelper/EverythingApiDllImport.cs
@@ -29,6 +29,9 @@ namespace Community.PowerToys.Run.Plugin.Everything.SearchHelper
 
         [DllImport(DllPath)]
         internal static extern void Everything_SetOffset(int dwOffset);
+        
+        [DllImport(DllPath)]
+        internal static extern void Everything_SetSort(int dwSort);
 
         [DllImport(DllPath)]
         internal static extern bool Everything_GetMatchPath();


### PR DESCRIPTION
Added sort order by modified date descending, especially useful when using wildcard search like *.pdf
